### PR TITLE
Wrong sort of source-url to be parsed by the list builder

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -16,8 +16,8 @@
         "Tony O'Dell"       
     ],
     "support" : {
-        "source"  : "git@github.com:tony-o/perl6-event-emitter.git",
+        "source"  : "git://github.com/tony-o/perl6-event-emitter.git",
         "bugtracker"  : "https://github.com/tony-o/perl6-event-emitter/issues"
     },
-    "source-url"  : "git@github.com:tony-o/perl6-event-emitter.git"
+    "source-url"  : "git://github.com/tony-o/perl6-event-emitter.git"
 }


### PR DESCRIPTION
Hi,
I couldn't work out why the module still wasn't showing up in the module list so I actually ran the program that generates it and found out :)
