### PR TITLE
Mention unit declarator in README docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Want to make your own receiver/emitter?  Here's a template
 ```perl6
 use Event::Emitter::Role::Handler;
 
-class My::Own::Emitter does Event::Emitter::Role::Handler;
+unit class My::Own::Emitter does Event::Emitter::Role::Handler;
 
 method on($event, $data) {
   qw<do your thing>;


### PR DESCRIPTION
In order that users of this module don't get the `unit` declarator deprecation warning straight away, this PR updates the README to include the `unit` declarator in the example template class.
