### PR TITLE
Use kebab-case in test function names

### DIFF
--- a/t/05-emitter-typed.t
+++ b/t/05-emitter-typed.t
@@ -32,13 +32,13 @@ ok(my $tap = $obj.on(MyEvent, { pass("event got handled"); $test_handled = True 
 
 $obj.on(BadEvent, { fail("different named event didn't get handled"); $boom_handled = True });
 
-lives_ok { $obj.emit(MyEvent.new) }, "emit with MyEvent works";
+lives-ok { $obj.emit(MyEvent.new) }, "emit with MyEvent works";
 
 ok($test_handled, "and test handler was right");
 ok(!$boom_handled, "and the other one wasn't called");
 
-dies_ok({ $obj.on(MyEvent,"bar") }, "dies with a non-code argument");
-dies_ok({ $obj.on("foo",{ say $_ }) }, "dies with a non-type argument");
+dies-ok({ $obj.on(MyEvent,"bar") }, "dies with a non-code argument");
+dies-ok({ $obj.on("foo",{ say $_ }) }, "dies with a non-type argument");
 
 class Bar does Event::Emitter::Role::Typed[:threaded] {
 }
@@ -52,6 +52,6 @@ ok($tap = $obj.on(MyEvent, { pass("event got handled (threaded)"); }), "set hand
 
 $obj.on(BadEvent, { fail("different named event didn't get handled (threaded)"); });
 
-lives_ok { $obj.emit(MyEvent.new) }, "emit with MyEvent works (threaded)";
+lives-ok { $obj.emit(MyEvent.new) }, "emit with MyEvent works (threaded)";
 
 


### PR DESCRIPTION
Test function names with underscores have been deprecated in favour of their
kebab-case variants.  The deprecated form will be removed in Rakudo 2015.09.
This change brings the test suite up to date with current Rakudo.
